### PR TITLE
Intalling device-mapper-event-libs

### DIFF
--- a/docs/sources/installation/centos.md
+++ b/docs/sources/installation/centos.md
@@ -32,6 +32,8 @@ run the following command:
     $ sudo yum install docker
 
 Please continue with the [Starting the Docker daemon](#starting-the-docker-daemon).
+Also, you may need to install "device-mapper-event-libs" in order to start Docker daemon. It can be done using:
+`sudo yum install device-mapper-event-libs`
 
 ### FirewallD
 


### PR DESCRIPTION
We need "device-mapper-event-libs" in CentOS 7 base image to start Docker daemon.
